### PR TITLE
send to bcc

### DIFF
--- a/lib/action_mailer/logged_smtp_delivery.rb
+++ b/lib/action_mailer/logged_smtp_delivery.rb
@@ -10,33 +10,23 @@ class ActionMailer::LoggedSMTPDelivery < Mail::SMTP
   end
 
   def deliver!(mail)
-    without_bcc(mail) do |mail|
-      if logger = settings[:mail_file_logger]
-        path = logger.log(mail.encoded)
-        log mail, "stored at #{path}"
-      end
-
-      log_headers(mail)
-      log mail, "sender: #{mail.sender}"
-      log mail, "destinations: #{mail.destinations.inspect}"
-
-      response = super
-
-      log mail, "done #{response.inspect}"
+    if logger = settings[:mail_file_logger]
+      path = logger.log(mail.encoded)
+      log mail, "stored at #{path}"
     end
+
+    log_headers(mail)
+    log mail, "sender: #{mail.sender}"
+    log mail, "destinations: #{mail.destinations.inspect}"
+
+    response = super
+
+    log mail, "done #{response.inspect}"
   end
 
   private
 
   attr_accessor :logger
-
-  def without_bcc(mail)
-    original_bcc = mail.bcc
-    mail.bcc     = nil
-    yield mail
-  ensure
-    mail.bcc = original_bcc
-  end
 
   def log_headers(mail)
     log mail, "#{log_header}: [#{mail[log_header]}]" if log_header

--- a/test/logged_smtp_delivery_test.rb
+++ b/test/logged_smtp_delivery_test.rb
@@ -105,7 +105,12 @@ class LoggedSMTPDeliveryTest < MiniTest::Unit::TestCase
 
     it 'does not include BCC addresses in the message' do
       TestMailer.welcome(:bcc => 'bcc@example.com').deliver
-      refute_includes mail[:to_list], "<bcc@example.com>"
+      refute_includes mail[:body], "bcc@example.com"
+    end
+
+    it 'sends to bcc addresses' do
+      TestMailer.welcome(:bcc => 'bcc@example.com').deliver
+      assert_includes mail[:to_list], "<bcc@example.com>"
     end
   end
 end


### PR DESCRIPTION
Turns out we need bcc for archiving to work, no idea why this code was there in the first place ... maybe to cover up come bug in smtp or our mail generator ...
Misread the old code as just removing the bcc, but it only removed it from the email message but kept it as recipient.
With this change email body still does not include the BCC header but the recipient, so nothing should change...

@morten @staugaard @steved555 @jcheatham 
### Risks
- None
