### PR TITLE
Update Rails version-specific gemfiles to use specific actionpack versions containing security fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mailcrate (0.0.3)
+    mailcrate (0.0.6)
     mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
@@ -79,11 +79,11 @@ DEPENDENCIES
   action_mailer-logged_smtp_delivery!
   bump
   byebug
-  mailcrate (>= 0.0.2)
+  mailcrate (>= 0.0.6)
   minitest
   minitest-rg
   rake
   wwtd
 
 BUNDLED WITH
-   1.12.0.pre.2
+   1.11.2

--- a/action_mailer-logged_smtp_delivery.gemspec
+++ b/action_mailer-logged_smtp_delivery.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bump'
   gem.add_development_dependency 'wwtd'
-  gem.add_development_dependency 'mailcrate', '>= 0.0.2'
+  gem.add_development_dependency 'mailcrate', '>= 0.0.6'
   gem.add_development_dependency 'byebug'
 end

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 gemspec :path=>"../"
 
-gem "actionmailer", "~> 3.2.18"
+gem "actionmailer", "~> 3.2.22.2"
 gem "test-unit"

--- a/gemfiles/rails3.2.gemfile.lock
+++ b/gemfiles/rails3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    action_mailer-logged_smtp_delivery (2.0.4)
+    action_mailer-logged_smtp_delivery (2.0.5)
       actionmailer (>= 3.2.22.2, < 5.1.0)
 
 GEM
@@ -36,7 +36,7 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mailcrate (0.0.3)
+    mailcrate (0.0.6)
     mime-types (1.25.1)
     minitest (5.8.4)
     minitest-rg (5.2.0)
@@ -68,10 +68,10 @@ PLATFORMS
 
 DEPENDENCIES
   action_mailer-logged_smtp_delivery!
-  actionmailer (~> 3.2.18)
+  actionmailer (~> 3.2.22.2)
   bump
   byebug
-  mailcrate (>= 0.0.2)
+  mailcrate (>= 0.0.6)
   minitest
   minitest-rg
   rake

--- a/gemfiles/rails4.1.gemfile
+++ b/gemfiles/rails4.1.gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec :path=>"../"
 
-gem "actionmailer", "~> 4.1.0"
+gem "actionmailer", "~> 4.1.14.2"

--- a/gemfiles/rails4.1.gemfile.lock
+++ b/gemfiles/rails4.1.gemfile.lock
@@ -1,26 +1,26 @@
 PATH
   remote: ../
   specs:
-    action_mailer-logged_smtp_delivery (2.0.4)
+    action_mailer-logged_smtp_delivery (2.0.5)
       actionmailer (>= 3.2.22.2, < 5.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (4.1.15)
-      actionpack (= 4.1.15)
-      actionview (= 4.1.15)
+    actionmailer (4.1.14.2)
+      actionpack (= 4.1.14.2)
+      actionview (= 4.1.14.2)
       mail (~> 2.5, >= 2.5.4)
-    actionpack (4.1.15)
-      actionview (= 4.1.15)
-      activesupport (= 4.1.15)
+    actionpack (4.1.14.2)
+      actionview (= 4.1.14.2)
+      activesupport (= 4.1.14.2)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
-    actionview (4.1.15)
-      activesupport (= 4.1.15)
+    actionview (4.1.14.2)
+      activesupport (= 4.1.14.2)
       builder (~> 3.1)
       erubis (~> 2.7.0)
-    activesupport (4.1.15)
+    activesupport (4.1.14.2)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -34,7 +34,7 @@ GEM
     json (1.8.3)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mailcrate (0.0.3)
+    mailcrate (0.0.6)
     mime-types (2.99.1)
     minitest (5.8.4)
     minitest-rg (5.2.0)
@@ -53,10 +53,10 @@ PLATFORMS
 
 DEPENDENCIES
   action_mailer-logged_smtp_delivery!
-  actionmailer (~> 4.1.0)
+  actionmailer (~> 4.1.14.2)
   bump
   byebug
-  mailcrate (>= 0.0.2)
+  mailcrate (>= 0.0.6)
   minitest
   minitest-rg
   rake

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -2,4 +2,4 @@ source "https://rubygems.org"
 
 gemspec :path=>"../"
 
-gem "actionmailer", "~> 4.2.0"
+gem "actionmailer", "~> 4.2.5.2"

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -1,35 +1,35 @@
 PATH
   remote: ../
   specs:
-    action_mailer-logged_smtp_delivery (2.0.4)
+    action_mailer-logged_smtp_delivery (2.0.5)
       actionmailer (>= 3.2.22.2, < 5.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (4.2.6)
-      actionpack (= 4.2.6)
-      actionview (= 4.2.6)
-      activejob (= 4.2.6)
+    actionmailer (4.2.5.2)
+      actionpack (= 4.2.5.2)
+      actionview (= 4.2.5.2)
+      activejob (= 4.2.5.2)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 1.0, >= 1.0.5)
-    actionpack (4.2.6)
-      actionview (= 4.2.6)
-      activesupport (= 4.2.6)
+    actionpack (4.2.5.2)
+      actionview (= 4.2.5.2)
+      activesupport (= 4.2.5.2)
       rack (~> 1.6)
       rack-test (~> 0.6.2)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (4.2.6)
-      activesupport (= 4.2.6)
+    actionview (4.2.5.2)
+      activesupport (= 4.2.5.2)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    activejob (4.2.6)
-      activesupport (= 4.2.6)
+    activejob (4.2.5.2)
+      activesupport (= 4.2.5.2)
       globalid (>= 0.3.0)
-    activesupport (4.2.6)
+    activesupport (4.2.5.2)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -47,7 +47,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mailcrate (0.0.3)
+    mailcrate (0.0.6)
     mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
@@ -77,10 +77,10 @@ PLATFORMS
 
 DEPENDENCIES
   action_mailer-logged_smtp_delivery!
-  actionmailer (~> 4.2.0)
+  actionmailer (~> 4.2.5.2)
   bump
   byebug
-  mailcrate (>= 0.0.2)
+  mailcrate (>= 0.0.6)
   minitest
   minitest-rg
   rake

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    action_mailer-logged_smtp_delivery (2.0.4)
+    action_mailer-logged_smtp_delivery (2.0.5)
       actionmailer (>= 3.2.22.2, < 5.1.0)
 
 GEM
@@ -47,7 +47,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mailcrate (0.0.3)
+    mailcrate (0.0.6)
     mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
@@ -81,7 +81,7 @@ DEPENDENCIES
   actionmailer (~> 5.0.0.beta1)
   bump
   byebug
-  mailcrate (>= 0.0.2)
+  mailcrate (>= 0.0.6)
   minitest
   minitest-rg
   rake


### PR DESCRIPTION
Use just the version containing the security fix for CVE-2016-2098 on its own first - can bump the rest of the actionmailer updates later if needed. Also updating mailcrate for test fixes. 

@grosser @melvinram @alduethadyn @mariozaizar 

### Risks
 - Low