### PR TITLE
[EM-858] adds tracking of datadog metrics to error response status types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,29 @@
 sudo: false
+
+before_install: bundle config https://gem.zdsys.com/gems/ $BUNDLE_GEM__ZDSYS__COM
+bundler_args: ""
+cache: bundler
+
+branches:
+  only: master
+
+before_script:
+ - git config --global user.email "you@example.com"
+ - git config --global user.name "Your Name"
+
+script : bundle exec rake test
+
 rvm:
  - 2.1.8
  - 2.2.4
  - 2.3.0
-script : bundle exec rake test
-bundler_args: ""
+
 gemfile:
   - gemfiles/rails3.2.gemfile
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
-cache: bundler
-branches:
-  only: master
+
 matrix:
   exclude:
     - rvm: 2.1.8

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -1,6 +1,10 @@
 source "https://rubygems.org"
 
-gemspec :path=>"../"
+gemspec path: "../"
 
 gem "actionmailer", "~> 3.2.22.2"
 gem "test-unit"
+
+source "https://gem.zdsys.com/gems/" do
+  gem "zendesk_statsd", "~> 0.4"
+end

--- a/gemfiles/rails3.2.gemfile.lock
+++ b/gemfiles/rails3.2.gemfile.lock
@@ -1,11 +1,12 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    action_mailer-logged_smtp_delivery (2.0.5)
+    action_mailer-logged_smtp_delivery (2.0.6)
       actionmailer (>= 3.2.22.2, < 5.1.0)
 
 GEM
   remote: https://rubygems.org/
+  remote: https://gem.zdsys.com/gems/
   specs:
     actionmailer (3.2.22.2)
       actionpack (= 3.2.22.2)
@@ -29,10 +30,13 @@ GEM
     builder (3.0.4)
     bump (0.5.3)
     byebug (8.2.1)
+    dogstatsd-ruby (2.2.0)
+    dotenv (2.2.0)
     erubis (2.7.0)
     hike (1.2.3)
     i18n (0.7.0)
     journey (1.0.4)
+    json (2.0.3)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -62,6 +66,12 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     wwtd (1.3.0)
+    zendesk_configuration (1.8.3)
+      dotenv
+      json
+    zendesk_statsd (0.4.5)
+      dogstatsd-ruby
+      zendesk_configuration (~> 1.5)
 
 PLATFORMS
   ruby
@@ -77,6 +87,7 @@ DEPENDENCIES
   rake
   test-unit
   wwtd
+  zendesk_statsd (~> 0.4)!
 
 BUNDLED WITH
-   1.11.2
+   1.14.4

--- a/gemfiles/rails4.1.gemfile
+++ b/gemfiles/rails4.1.gemfile
@@ -1,5 +1,9 @@
 source "https://rubygems.org"
 
-gemspec :path=>"../"
+gemspec path: "../"
 
 gem "actionmailer", "~> 4.1.14.2"
+
+source "https://gem.zdsys.com/gems/" do
+  gem "zendesk_statsd", "~> 0.4"
+end

--- a/gemfiles/rails4.1.gemfile.lock
+++ b/gemfiles/rails4.1.gemfile.lock
@@ -1,11 +1,12 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    action_mailer-logged_smtp_delivery (2.0.5)
+    action_mailer-logged_smtp_delivery (2.0.6)
       actionmailer (>= 3.2.22.2, < 5.1.0)
 
 GEM
   remote: https://rubygems.org/
+  remote: https://gem.zdsys.com/gems/
   specs:
     actionmailer (4.1.14.2)
       actionpack (= 4.1.14.2)
@@ -29,6 +30,8 @@ GEM
     builder (3.2.2)
     bump (0.5.3)
     byebug (8.2.1)
+    dogstatsd-ruby (2.2.0)
+    dotenv (2.2.0)
     erubis (2.7.0)
     i18n (0.7.0)
     json (1.8.3)
@@ -47,6 +50,12 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     wwtd (1.3.0)
+    zendesk_configuration (1.8.3)
+      dotenv
+      json
+    zendesk_statsd (0.4.5)
+      dogstatsd-ruby
+      zendesk_configuration (~> 1.5)
 
 PLATFORMS
   ruby
@@ -61,6 +70,7 @@ DEPENDENCIES
   minitest-rg
   rake
   wwtd
+  zendesk_statsd (~> 0.4)!
 
 BUNDLED WITH
-   1.11.2
+   1.14.4

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,5 +1,9 @@
 source "https://rubygems.org"
 
-gemspec :path=>"../"
+gemspec path: "../"
 
 gem "actionmailer", "~> 4.2.5.2"
+
+source "https://gem.zdsys.com/gems/" do
+  gem "zendesk_statsd", "~> 0.4"
+end

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -1,11 +1,12 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    action_mailer-logged_smtp_delivery (2.0.5)
+    action_mailer-logged_smtp_delivery (2.0.6)
       actionmailer (>= 3.2.22.2, < 5.1.0)
 
 GEM
   remote: https://rubygems.org/
+  remote: https://gem.zdsys.com/gems/
   specs:
     actionmailer (4.2.5.2)
       actionpack (= 4.2.5.2)
@@ -38,6 +39,8 @@ GEM
     builder (3.2.2)
     bump (0.5.3)
     byebug (8.2.1)
+    dogstatsd-ruby (2.2.0)
+    dotenv (2.2.0)
     erubis (2.7.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -71,6 +74,12 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     wwtd (1.3.0)
+    zendesk_configuration (1.8.3)
+      dotenv
+      json
+    zendesk_statsd (0.4.5)
+      dogstatsd-ruby
+      zendesk_configuration (~> 1.5)
 
 PLATFORMS
   ruby
@@ -85,6 +94,7 @@ DEPENDENCIES
   minitest-rg
   rake
   wwtd
+  zendesk_statsd (~> 0.4)!
 
 BUNDLED WITH
-   1.11.2
+   1.14.4

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,5 +1,9 @@
 source "https://rubygems.org"
 
-gemspec :path=>"../"
+gemspec path: "../"
 
 gem "actionmailer", "~> 5.0.0.beta1"
+
+source "https://gem.zdsys.com/gems/" do
+  gem "zendesk_statsd", "~> 0.4"
+end

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -1,11 +1,12 @@
 PATH
-  remote: ../
+  remote: ..
   specs:
-    action_mailer-logged_smtp_delivery (2.0.5)
+    action_mailer-logged_smtp_delivery (2.0.6)
       actionmailer (>= 3.2.22.2, < 5.1.0)
 
 GEM
   remote: https://rubygems.org/
+  remote: https://gem.zdsys.com/gems/
   specs:
     actionmailer (5.0.0.beta3)
       actionpack (= 5.0.0.beta3)
@@ -38,6 +39,8 @@ GEM
     bump (0.5.3)
     byebug (8.2.1)
     concurrent-ruby (1.0.1)
+    dogstatsd-ruby (2.2.0)
+    dotenv (2.2.0)
     erubis (2.7.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -72,6 +75,12 @@ GEM
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     wwtd (1.3.0)
+    zendesk_configuration (1.8.3)
+      dotenv
+      json
+    zendesk_statsd (0.4.5)
+      dogstatsd-ruby
+      zendesk_configuration (~> 1.5)
 
 PLATFORMS
   ruby
@@ -86,6 +95,7 @@ DEPENDENCIES
   minitest-rg
   rake
   wwtd
+  zendesk_statsd (~> 0.4)!
 
 BUNDLED WITH
-   1.11.2
+   1.14.4


### PR DESCRIPTION
### Description

Adds the ability to track error response status codes/values in datadog, if `settings[:log_and_record_results]` is set/true.

@zendesk/strongbad 

### Next Steps

- [ ] Needs tests
- [ ] Pull in to classic and set option behind an Arturo

### Risks

Medium - adds a lot of potential datadog volume