### PR TITLE
[ESP-12] Store the the EmailID from the SMTP response

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,9 +14,6 @@ jobs:
       max-parallel: 20
       matrix:
         rvm:
-          - 2.2.10
-          - 2.3.4
-          - 2.4.1
           - 2.5.8
           - 2.6
           - 2.7
@@ -28,9 +25,6 @@ jobs:
         task:
           - rake test
         exclude:
-          - rvm: 2.4.1
-            gemfile: gemfiles/rails3.2.gemfile
-            task: rake test
           - rvm: 2.7
             gemfile: gemfiles/rails3.2.gemfile
             task: rake test

--- a/lib/action_mailer/logged_smtp_delivery.rb
+++ b/lib/action_mailer/logged_smtp_delivery.rb
@@ -2,11 +2,10 @@ require 'action_mailer'
 require 'mail/network/delivery_methods/smtp'
 
 class ActionMailer::LoggedSMTPDelivery < Mail::SMTP
-
   # The ULID pattern conforms with the spec - https://github.com/ulid/spec#encoding
   # a. Canonically encoded as a 26 character string
   # b. Excludes the letters I, L, O, and U to avoid confusion and abuse.
-  ULID_PATTERN = /[A-HJKMNV-Z0-9]{26}/.freeze
+  ULID_PATTERN = /(?!.*[ILOU])[A-Z0-9]{26}/.freeze
 
   def initialize(settings)
     super

--- a/lib/action_mailer/logged_smtp_delivery.rb
+++ b/lib/action_mailer/logged_smtp_delivery.rb
@@ -2,7 +2,11 @@ require 'action_mailer'
 require 'mail/network/delivery_methods/smtp'
 
 class ActionMailer::LoggedSMTPDelivery < Mail::SMTP
-  ULID_PATTERN = /[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}/.freeze
+
+  # The ULID pattern conforms with the spec - https://github.com/ulid/spec#encoding
+  # a. Canonically encoded as a 26 character string
+  # b. Excludes the letters I, L, O, and U to avoid confusion and abuse.
+  ULID_PATTERN = /[A-HJKMNV-Z0-9]{26}/.freeze
 
   def initialize(settings)
     super

--- a/lib/action_mailer/logged_smtp_delivery.rb
+++ b/lib/action_mailer/logged_smtp_delivery.rb
@@ -21,6 +21,7 @@ class ActionMailer::LoggedSMTPDelivery < Mail::SMTP
 
     response = super
 
+    mail.header[:smtp_response] = response.message
     log mail, "done #{response.inspect}"
   end
 

--- a/lib/action_mailer/logged_smtp_delivery.rb
+++ b/lib/action_mailer/logged_smtp_delivery.rb
@@ -2,7 +2,7 @@ require 'action_mailer'
 require 'mail/network/delivery_methods/smtp'
 
 class ActionMailer::LoggedSMTPDelivery < Mail::SMTP
-  ULID_PATTERN = /[A-Z0-9]{26}/.freeze
+  ULID_PATTERN = /[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}/.freeze
 
   def initialize(settings)
     super
@@ -22,7 +22,7 @@ class ActionMailer::LoggedSMTPDelivery < Mail::SMTP
     log mail, "destinations: #{mail.destinations.inspect}"
 
     response = super
-    set_email_id(mail, response&.message)
+    store_email_id(mail, response)
 
     log mail, "done #{response.inspect}"
   end
@@ -43,10 +43,11 @@ class ActionMailer::LoggedSMTPDelivery < Mail::SMTP
     logger.info("#{mail.message_id} #{message}")
   end
 
-  def set_email_id(mail, response_message)
-    return if response_message.nil?
+  def store_email_id(mail, response)
+    return unless response.respond_to?(:message)
+    return if response&.message.nil?
 
-    email_id = response_message[ULID_PATTERN, 0]
+    email_id = response.message[ULID_PATTERN, 0]
     mail.header[:email_id] = email_id unless email_id.nil?
   end
 end

--- a/test/logged_smtp_delivery_test.rb
+++ b/test/logged_smtp_delivery_test.rb
@@ -126,5 +126,10 @@ class LoggedSMTPDeliveryTest < Minitest::Test
       TestMailer.welcome(:bcc => 'bcc@example.com').send(DELIVER_METHOD)
       assert_includes mail[:to_list], "<bcc@example.com>"
     end
+
+    it 'store the smtp response message in mta_email_id header' do
+      message = TestMailer.welcome(:from => [ 'a@example.com', 'b@example.com' ]).send(DELIVER_METHOD)
+      assert_includes message.header['smtp-response'].value, "250 ok"
+    end
   end
 end

--- a/test/logged_smtp_delivery_test.rb
+++ b/test/logged_smtp_delivery_test.rb
@@ -145,6 +145,17 @@ class LoggedSMTPDeliveryTest < Minitest::Test
       end
     end
 
+    describe 'when the smtp response message contains an invalid ulid value' do
+      let(:mailer) { ActionMailer::LoggedSMTPDelivery.new(TestMailer.logged_smtp_settings) }
+      let(:response) { Net::SMTP::Response.parse('250 2.0.0 OK cec04206-d395 [01EN822WVWWDQ8IY6ZT1BACHHR]') }
+
+      it 'does not store the email id' do
+        message = TestMailer.welcome(:from => [ 'a@example.com', 'b@example.com' ]).send(DELIVER_METHOD)
+        mailer.send(:store_email_id, message, response)
+        refute message.header['email_id']
+      end
+    end
+
     describe 'when the smtp response message is nil' do
       let(:mailer) { ActionMailer::LoggedSMTPDelivery.new(TestMailer.logged_smtp_settings) }
       let(:response) { Net::SMTP::Response.parse('') }

--- a/test/logged_smtp_delivery_test.rb
+++ b/test/logged_smtp_delivery_test.rb
@@ -136,11 +136,34 @@ class LoggedSMTPDeliveryTest < Minitest::Test
 
     describe 'when the smtp response message contains an ulid value' do
       let(:mailer) { ActionMailer::LoggedSMTPDelivery.new(TestMailer.logged_smtp_settings) }
+      let(:response) { Net::SMTP::Response.parse('250 2.0.0 OK cec04206-d395 [01EN822WVWWDQ8Y6ZT1BACHHRM]') }
 
       it 'stores the id in email_id header' do
         message = TestMailer.welcome(:from => [ 'a@example.com', 'b@example.com' ]).send(DELIVER_METHOD)
-        mailer.send(:set_email_id, message, "250 2.0.0 OK cec04206-d395 [01EN822WVWWDQ8Y6ZT1BACHHRM]")
+        mailer.send(:store_email_id, message, response)
         assert_includes message.header['email_id'].value, '01EN822WVWWDQ8Y6ZT1BACHHRM'
+      end
+    end
+
+    describe 'when the smtp response message is nil' do
+      let(:mailer) { ActionMailer::LoggedSMTPDelivery.new(TestMailer.logged_smtp_settings) }
+      let(:response) { Net::SMTP::Response.parse('') }
+
+      it 'does not store the email id' do
+        message = TestMailer.welcome(:from => [ 'a@example.com', 'b@example.com' ]).send(DELIVER_METHOD)
+        mailer.send(:store_email_id, message, response)
+        refute message.header['email_id']
+      end
+    end
+
+    describe 'when the smtp response object passed to store_email_id method is nil' do
+      let(:mailer) { ActionMailer::LoggedSMTPDelivery.new(TestMailer.logged_smtp_settings) }
+      let(:response) { Net::SMTP::Response.parse('') }
+
+      it 'does not store the email id' do
+        message = TestMailer.welcome(:from => [ 'a@example.com', 'b@example.com' ]).send(DELIVER_METHOD)
+        mailer.send(:store_email_id, message, nil)
+        refute message.header['email_id']
       end
     end
   end


### PR DESCRIPTION
**Description:**
The PR adds a code path to store the ULID EmailID value from the SMTP response to a `Mail::Message` header - `email_id`. 
The regex to detect the presence of ULID value conforms with spec - https://github.com/ulid/spec#encoding : 
- Canonically encoded as a 26 character string
- Excludes the letters I, L, O, and U to avoid confusion and abuse.

When the SMTP response (from Postfix) doesn't return a ULID value in the message, `Mail::Message` will not contain a header `email_id`.  We have added a few additional tests to confirm if this behavior and cover some edge case scenarios.

**JIRA:**
https://zendesk.atlassian.net/browse/ESP-12

**Risk**
Low - The code path to store EmailID from SMTP response if present. We have some additional precaution checks - `response.respond_to?(:message) ` and `response&.message.nil?` to handle edge case scenarios. 
