### PR TITLE
[ESP-12] Remove the logic to store the EmailID from the SMTP response

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.rvm }}
     - name: setup_env
-      run: echo "::set-env name=BUNDLE_GEMFILE::$GITHUB_WORKSPACE/${{ matrix.gemfile }}"
+      run: echo "BUNDLE_GEMFILE=$GITHUB_WORKSPACE/${{ matrix.gemfile }}" >> $GITHUB_ENV
       shell: bash
     - name: install
       run: bundle install --without debug documentation

--- a/lib/action_mailer/logged_smtp_delivery.rb
+++ b/lib/action_mailer/logged_smtp_delivery.rb
@@ -2,16 +2,14 @@ require 'action_mailer'
 require 'mail/network/delivery_methods/smtp'
 
 class ActionMailer::LoggedSMTPDelivery < Mail::SMTP
-  # The ULID pattern conforms with the spec - https://github.com/ulid/spec#encoding
-  # a. Canonically encoded as a 26 character string
-  # b. Excludes the letters I, L, O, and U to avoid confusion and abuse.
-  ULID_PATTERN = /(?!.*[ILOU])[A-Z0-9]{26}/.freeze
+  attr_accessor :response
 
   def initialize(settings)
     super
     self.settings[:tls] = (settings[:tls] != false)
     self.settings[:return_response] = true
     self.logger = settings[:logger]
+    self.response = nil
   end
 
   def deliver!(mail)
@@ -24,9 +22,7 @@ class ActionMailer::LoggedSMTPDelivery < Mail::SMTP
     log mail, "sender: #{mail.sender}"
     log mail, "destinations: #{mail.destinations.inspect}"
 
-    response = super
-    store_email_id(mail, response)
-
+    self.response = super
     log mail, "done #{response.inspect}"
   end
 
@@ -44,14 +40,6 @@ class ActionMailer::LoggedSMTPDelivery < Mail::SMTP
 
   def log(mail, message)
     logger.info("#{mail.message_id} #{message}")
-  end
-
-  def store_email_id(mail, response)
-    return unless response.respond_to?(:message)
-    return if response&.message.nil?
-
-    email_id = response.message[ULID_PATTERN, 0]
-    mail.header[:email_id] = email_id unless email_id.nil?
   end
 end
 


### PR DESCRIPTION
**Description:**
- Remove all the code path added in this PR - https://github.com/zendesk/action_mailer-logged_smtp_delivery/pull/11 to store the ULID EmailID value from the SMTP response to a `Mail::Message` header - `email_id`. 
This logic could be done generically as this gem is only supposed to add the logging functionality. 

- Surfaces an instance variable `response` that can be used by the subclass which can then do the mail modifications needed.

**JIRA:**
https://zendesk.atlassian.net/browse/ESP-12

**Risk**
Low - The changes should not impact the logging functionality. 
