### PR TITLE
Adds compatibility with Rails 5.2 and Rails 6.0

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,6 +22,8 @@ jobs:
           - gemfiles/rails4.2.gemfile
           - gemfiles/rails5.0.gemfile
           - gemfiles/rails5.1.gemfile
+          - gemfiles/rails5.2.gemfile
+          - gemfiles/rails6.0.gemfile
         task:
           - rake test
         exclude:
@@ -37,6 +39,8 @@ jobs:
       run: echo "BUNDLE_GEMFILE=$GITHUB_WORKSPACE/${{ matrix.gemfile }}" >> $GITHUB_ENV
       shell: bash
     - name: install
-      run: bundle install --without debug documentation
+      run: |
+        gem update --system
+        bundle install --without debug documentation
     - name: Run ${{ matrix.task }} with Ruby ${{ matrix.rvm }} and ${{ matrix.gemfile }}
       run: bundle exec ${{ matrix.task }}

--- a/action_mailer-logged_smtp_delivery.gemspec
+++ b/action_mailer-logged_smtp_delivery.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.version       = '2.1.2'
   gem.license       = "Apache V2"
 
-  gem.add_runtime_dependency 'actionmailer', '>= 3.2.22.2', '< 5.2.0'
+  gem.add_runtime_dependency 'actionmailer', '>= 3.2.22.2', '< 6.1.0'
 
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'minitest-rg'

--- a/gemfiles/rails3.2.gemfile.lock
+++ b/gemfiles/rails3.2.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    action_mailer-logged_smtp_delivery (2.0.6)
-      actionmailer (>= 3.2.22.2, < 5.2.0)
+    action_mailer-logged_smtp_delivery (2.1.2)
+      actionmailer (>= 3.2.22.2, < 6.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -79,4 +79,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.14.6
+   1.17.3

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    action_mailer-logged_smtp_delivery (2.0.6)
-      actionmailer (>= 3.2.22.2, < 5.2.0)
+    action_mailer-logged_smtp_delivery (2.1.2)
+      actionmailer (>= 3.2.22.2, < 6.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -89,4 +89,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.14.6
+   1.17.3

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    action_mailer-logged_smtp_delivery (2.0.6)
-      actionmailer (>= 3.2.22.2, < 5.2.0)
+    action_mailer-logged_smtp_delivery (2.1.2)
+      actionmailer (>= 3.2.22.2, < 6.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -85,4 +85,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.14.6
+   1.17.3

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    action_mailer-logged_smtp_delivery (2.0.6)
-      actionmailer (>= 3.2.22.2, < 5.2.0)
+    action_mailer-logged_smtp_delivery (2.1.2)
+      actionmailer (>= 3.2.22.2, < 6.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -85,4 +85,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.14.6
+   1.17.3

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'actionmailer', '~> 5.2'

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: .
+  remote: ..
   specs:
     action_mailer-logged_smtp_delivery (2.1.2)
       actionmailer (>= 3.2.22.2, < 6.1.0)
@@ -7,37 +7,36 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (6.0.3.4)
-      actionpack (= 6.0.3.4)
-      actionview (= 6.0.3.4)
-      activejob (= 6.0.3.4)
+    actionmailer (5.2.4.4)
+      actionpack (= 5.2.4.4)
+      actionview (= 5.2.4.4)
+      activejob (= 5.2.4.4)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (6.0.3.4)
-      actionview (= 6.0.3.4)
-      activesupport (= 6.0.3.4)
+    actionpack (5.2.4.4)
+      actionview (= 5.2.4.4)
+      activesupport (= 5.2.4.4)
       rack (~> 2.0, >= 2.0.8)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (6.0.3.4)
-      activesupport (= 6.0.3.4)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.2.4.4)
+      activesupport (= 5.2.4.4)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (6.0.3.4)
-      activesupport (= 6.0.3.4)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activejob (5.2.4.4)
+      activesupport (= 5.2.4.4)
       globalid (>= 0.3.6)
-    activesupport (6.0.3.4)
+    activesupport (5.2.4.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
     builder (3.2.4)
-    bump (0.5.3)
-    byebug (8.2.1)
+    bump (0.10.0)
+    byebug (11.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     erubi (1.10.0)
@@ -53,7 +52,7 @@ GEM
     mailcrate (0.0.6)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.8.4)
+    minitest (5.14.2)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
     nokogiri (1.10.10)
@@ -66,18 +65,18 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rake (10.5.0)
+    rake (13.0.1)
     thread_safe (0.3.6)
     tzinfo (1.2.8)
       thread_safe (~> 0.1)
-    wwtd (1.3.0)
-    zeitwerk (2.4.2)
+    wwtd (1.4.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   action_mailer-logged_smtp_delivery!
+  actionmailer (~> 5.2)
   bump
   byebug
   mailcrate (>= 0.0.6)
@@ -87,4 +86,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'actionmailer', '~> 6.0'

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -1,5 +1,5 @@
 PATH
-  remote: .
+  remote: ..
   specs:
     action_mailer-logged_smtp_delivery (2.1.2)
       actionmailer (>= 3.2.22.2, < 6.1.0)
@@ -36,8 +36,8 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
     builder (3.2.4)
-    bump (0.5.3)
-    byebug (8.2.1)
+    bump (0.10.0)
+    byebug (11.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     erubi (1.10.0)
@@ -53,7 +53,7 @@ GEM
     mailcrate (0.0.6)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.8.4)
+    minitest (5.14.2)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
     nokogiri (1.10.10)
@@ -66,11 +66,11 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rake (10.5.0)
+    rake (13.0.1)
     thread_safe (0.3.6)
     tzinfo (1.2.8)
       thread_safe (~> 0.1)
-    wwtd (1.3.0)
+    wwtd (1.4.1)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -78,6 +78,7 @@ PLATFORMS
 
 DEPENDENCIES
   action_mailer-logged_smtp_delivery!
+  actionmailer (~> 6.0)
   bump
   byebug
   mailcrate (>= 0.0.6)
@@ -87,4 +88,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/script/bundle
+++ b/script/bundle
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export BUNDLE_CMD=$@
+
+echo "Running this command all Gemfiles: $ bundle $BUNDLE_CMD"
+
+find . -maxdepth 2 -iname '*gemfile' | xargs -P10 -L1 -I % sh -c "BUNDLE_GEMFILE="%" bundle $BUNDLE_CMD"


### PR DESCRIPTION
Adds compatibility for the Rails 5.2 and Rails 6.0 versions.

Currently, the client on runtime versions - Rails 5.2 and Rails 6.0 can not find compatible versions for gem "actionmailer" and unable to resolve the dependencies. 
E.g., https://github.com/zendesk/zendesk_outgoing_mail/pull/241/checks?check_run_id=1517197714 

 