### PR TITLE
only log `done` when the delivery succeeded; log an error upon exception.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
     minitest (5.16.3)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
+    mocha (2.0.2)
+      ruby2_keywords (>= 0.0.5)
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -69,6 +71,7 @@ GEM
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rake (13.0.6)
+    ruby2_keywords (0.0.5)
     thread_safe (0.3.6)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
@@ -84,7 +87,8 @@ DEPENDENCIES
   mailcrate (>= 0.0.6)
   minitest
   minitest-rg
+  mocha
   rake
 
 BUNDLED WITH
-   2.3.21
+   2.3.23

--- a/action_mailer-logged_smtp_delivery.gemspec
+++ b/action_mailer-logged_smtp_delivery.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'bump'
   gem.add_development_dependency 'mailcrate', '>= 0.0.6'
   gem.add_development_dependency 'byebug'
+  gem.add_development_dependency 'mocha'
 end

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -55,6 +55,8 @@ GEM
     minitest (5.16.3)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
+    mocha (2.0.2)
+      ruby2_keywords (>= 0.0.5)
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -68,6 +70,7 @@ GEM
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rake (13.0.6)
+    ruby2_keywords (0.0.5)
     thread_safe (0.3.6)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
@@ -83,7 +86,8 @@ DEPENDENCIES
   mailcrate (>= 0.0.6)
   minitest
   minitest-rg
+  mocha
   rake
 
 BUNDLED WITH
-   2.3.21
+   2.3.23

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -55,6 +55,8 @@ GEM
     minitest (5.16.3)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
+    mocha (2.0.2)
+      ruby2_keywords (>= 0.0.5)
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -68,6 +70,7 @@ GEM
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rake (13.0.6)
+    ruby2_keywords (0.0.5)
     thread_safe (0.3.6)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
@@ -83,7 +86,8 @@ DEPENDENCIES
   mailcrate (>= 0.0.6)
   minitest
   minitest-rg
+  mocha
   rake
 
 BUNDLED WITH
-   2.3.21
+   2.3.23

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -56,6 +56,8 @@ GEM
     minitest (5.16.3)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
+    mocha (2.0.2)
+      ruby2_keywords (>= 0.0.5)
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -69,6 +71,7 @@ GEM
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rake (13.0.6)
+    ruby2_keywords (0.0.5)
     thread_safe (0.3.6)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
@@ -85,7 +88,8 @@ DEPENDENCIES
   mailcrate (>= 0.0.6)
   minitest
   minitest-rg
+  mocha
   rake
 
 BUNDLED WITH
-   2.3.21
+   2.3.23

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -57,6 +57,8 @@ GEM
     minitest (5.16.3)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
+    mocha (2.0.2)
+      ruby2_keywords (>= 0.0.5)
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -70,6 +72,7 @@ GEM
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rake (13.0.6)
+    ruby2_keywords (0.0.5)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     zeitwerk (2.6.0)
@@ -85,7 +88,8 @@ DEPENDENCIES
   mailcrate (>= 0.0.6)
   minitest
   minitest-rg
+  mocha
   rake
 
 BUNDLED WITH
-   2.3.21
+   2.3.23

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -60,6 +60,8 @@ GEM
     minitest (5.16.3)
     minitest-rg (5.2.0)
       minitest (~> 5.0)
+    mocha (2.0.2)
+      ruby2_keywords (>= 0.0.5)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -87,6 +89,7 @@ GEM
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     rake (13.0.6)
+    ruby2_keywords (0.0.5)
     strscan (3.0.4)
     timeout (0.3.0)
     tzinfo (2.0.5)
@@ -103,7 +106,8 @@ DEPENDENCIES
   mailcrate (>= 0.0.6)
   minitest
   minitest-rg
+  mocha
   rake
 
 BUNDLED WITH
-   2.3.21
+   2.3.23

--- a/lib/action_mailer/logged_smtp_delivery.rb
+++ b/lib/action_mailer/logged_smtp_delivery.rb
@@ -13,8 +13,8 @@ class ActionMailer::LoggedSMTPDelivery < Mail::SMTP
   end
 
   def deliver!(mail)
-    if logger = settings[:mail_file_logger]
-      path = logger.log(mail.encoded)
+    if file_logger = settings[:mail_file_logger]
+      path = file_logger.log(mail.encoded)
       log mail, "stored at #{path}"
     end
 
@@ -22,8 +22,13 @@ class ActionMailer::LoggedSMTPDelivery < Mail::SMTP
     log mail, "sender: #{mail.sender}"
     log mail, "destinations: #{mail.destinations.inspect}"
 
-    self.response = super
-    log mail, "done #{response.inspect}"
+    begin
+      self.response = super
+      log mail, "done #{response.inspect}"
+    rescue => e
+      logger.error("#{mail.message_id} exception #{e.inspect}")
+      raise
+    end
   end
 
   private

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,6 +3,7 @@ require 'action_mailer/logged_smtp_delivery'
 
 require 'minitest/autorun'
 require 'minitest/rg'
+require 'mocha/minitest'
 require 'logger'
 require 'mailcrate'
 
@@ -21,41 +22,5 @@ class MemoryLogger
 
   def clear
     messages.clear
-  end
-end
-
-class FakeSMTP
-  attr_reader :address, :port, :credentials
-
-  def self.deliveries
-    @deliveries ||= []
-  end
-
-  def initialize(address, port)
-    @address = address
-    @port    = port
-  end
-
-  def start(*credentials)
-    @credentials = credentials
-    @started     = true
-
-    yield(self)
-  end
-
-  def send_message(message, from, recipients)
-    self.class.deliveries << [ message, from, recipients ]
-  end
-
-  def enable_starttls_auto
-    @starttls = :auto
-  end
-
-  def starttls_auto?
-    @starttls == :auto
-  end
-
-  def inspect
-    "#<#{self.class} #{@address}:#{@port} started=#{@started}>"
   end
 end

--- a/test/logged_smtp_delivery_test.rb
+++ b/test/logged_smtp_delivery_test.rb
@@ -128,5 +128,14 @@ class LoggedSMTPDeliveryTest < Minitest::Test
       _(mailer.response).must_be_kind_of Net::SMTP::Response
       _(mailer.response.status).must_equal '250'
     end
+
+    describe 'delivery failures' do
+      it 'logs any StandardError being thrown by the delivery method' do
+        Net::SMTP.any_instance.stubs(:rcptto_list).raises(StandardError.new("kaboom"))
+        assert_raises(StandardError) { TestMailer.welcome.deliver_now }
+        assert_includes log.string, '12345@example.com exception #<StandardError: kaboom>'
+        refute_includes log.string, 'done'
+      end
+    end
   end
 end


### PR DESCRIPTION
When Net::SMTP raises an exception, this logger didn't previously have
anything to say. Now, it logs that outcome.